### PR TITLE
3.0.0 and review changes - PART 1

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,46 @@
+{
+    // Verwendet IntelliSense zum Ermitteln möglicher Attribute.
+    // Zeigen Sie auf vorhandene Attribute, um die zugehörigen Beschreibungen anzuzeigen.
+    // Weitere Informationen finden Sie unter https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch normal",
+            "program": "${workspaceFolder}/main.js",
+            "args": ["--instance", "0", "--force", "--logs", "--debug"],
+            "request": "launch",
+            "stopOnEntry": true,
+            "console": "internalConsole",
+            "outputCapture": "std",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "type": "node"
+        },
+    
+        {
+            "name": "Launch install",
+            "program": "${workspaceFolder}/main.js",
+            "args": ["--instance", "0", "--force", "--logs", "--debug", "--install"],
+            "request": "launch",
+            "stopOnEntry": true,
+            "console": "internalConsole",
+            "outputCapture": "std",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "type": "node"
+        },
+    
+
+        {
+            "name": "Attach by Process ID",
+            "processId": "${command:PickProcess}",
+            "request": "attach",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "type": "node"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,19 +1,18 @@
 {
-	"eslint.enable": true,
-	"json.schemas": [
-		{
-			"fileMatch": [
-				"io-package.json"
-			],
-			"url": "https://json.schemastore.org/io-package"
-		},
-		{
-			"fileMatch": [
-				"admin/jsonConfig.json",
-				"admin/jsonCustom.json",
-				"admin/jsonTab.json"
-			],
-			"url": "https://raw.githubusercontent.com/ioBroker/adapter-react-v5/main/schemas/jsonConfig.json"
-		}
-	]
-}
+    "eslint.enable": true,
+    "json.schemas": [
+        {
+            "fileMatch": [
+                "io-package.json"
+            ],
+            "url": "https://raw.githubusercontent.com/ioBroker/ioBroker.js-controller/master/schemas/io-package.json"
+        },
+        {
+            "fileMatch": [
+                "admin/jsonConfig.json",
+                "admin/jsonCustom.json",
+                "admin/jsonTab.json"
+            ],
+            "url": "https://raw.githubusercontent.com/ioBroker/adapter-react-v5/main/schemas/jsonConfig.json"
+        }
+    ]}

--- a/README.md
+++ b/README.md
@@ -11,10 +11,13 @@
 **Tests:** ![Test and Release](https://github.com/iobroker-community-adapters/ioBroker.bayernluft/workflows/Test%20and%20Release/badge.svg)
 
 ## BayernLuft Adapter for ioBroker
-Connects BayernLuft into IoBroker
+Connects ventilation device manufactured by [BayernLuft](https://www.bayernluft.de/) to IoBroker systems.
+
+## Disclaimer
+**All product and company names or logos are trademarks™ or registered® trademarks of their respective holders. Use of them does not imply any affiliation with or endorsement by them or any associated subsidiaries! This personal project is maintained in spare time and has no business goal.**
 
 ## What needs to be done?
-To use this adapter, you need to change the export template of the device
+To use this adapter, you need to change the export template of the device.  
 **Be sure to follow the steps below**
 
 ## How to change the Template?

--- a/admin/i18n/de/translations.json
+++ b/admin/i18n/de/translations.json
@@ -5,5 +5,6 @@
     "lblIp": "IP Adresse",
     "lblPort": "Port",
     "lblName": "Name",
-    "lblDevices": "Geräte"
+    "lblDevices": "Geräte",
+    "lblEnabled": "Aktiv"
 }

--- a/admin/i18n/en/translations.json
+++ b/admin/i18n/en/translations.json
@@ -5,6 +5,7 @@
 	"lblIp": "IP Address",
 	"lblPort": "Port",
 	"lblName":"Name",
-	"lblDevices":"Devices"
+	"lblDevices":"Devices",
+	"lblEnabled":"Enabled"
 
 }

--- a/admin/i18n/es/translations.json
+++ b/admin/i18n/es/translations.json
@@ -5,5 +5,6 @@
     "lblIp": "Dirección IP",
     "lblPort": "Puerto",
     "lblName": "Nombre",
-    "lblDevices": "Dispositivos"
+    "lblDevices": "Dispositivos",
+    "lblEnabled": "Activado"
 }

--- a/admin/i18n/fr/translations.json
+++ b/admin/i18n/fr/translations.json
@@ -5,5 +5,6 @@
     "lblIp": "Adresse IP",
     "lblPort": "Port",
     "lblName": "Nom",
-    "lblDevices": "Appareils"
+    "lblDevices": "Appareils",
+    "lblEnabled": "Activé"
 }

--- a/admin/i18n/it/translations.json
+++ b/admin/i18n/it/translations.json
@@ -5,5 +5,6 @@
     "lblIp": "Indirizzo IP",
     "lblPort": "Porta",
     "lblName": "Nome",
-    "lblDevices": "Dispositivi"
+    "lblDevices": "Dispositivi",
+    "lblEnabled": "Abilitato"
 }

--- a/admin/i18n/nl/translations.json
+++ b/admin/i18n/nl/translations.json
@@ -5,5 +5,6 @@
     "lblIp": "IP adres",
     "lblPort": "Haven",
     "lblName": "Naam",
-    "lblDevices": "Apparaten"
+    "lblDevices": "Apparaten",
+    "lblEnabled": "Ingeschakeld"
 }

--- a/admin/i18n/pl/translations.json
+++ b/admin/i18n/pl/translations.json
@@ -5,5 +5,6 @@
     "lblIp": "Adres IP",
     "lblPort": "Port",
     "lblName": "Nazwa",
-    "lblDevices": "Urządzenia"
+    "lblDevices": "Urządzenia",
+    "lblEnabled": "Włączony"
 }

--- a/admin/i18n/pt/translations.json
+++ b/admin/i18n/pt/translations.json
@@ -5,5 +5,6 @@
     "lblIp": "Endereço de IP",
     "lblPort": "Porta",
     "lblName": "Nome",
-    "lblDevices": "Dispositivos"
+    "lblDevices": "Dispositivos",
+    "lblEnabled": "Habilitado"
 }

--- a/admin/i18n/ru/translations.json
+++ b/admin/i18n/ru/translations.json
@@ -5,5 +5,6 @@
     "lblIp": "Айпи адрес",
     "lblPort": "Порт",
     "lblName": "Имя",
-    "lblDevices": "Устройства"
+    "lblDevices": "Устройства",
+    "lblEnabled": "Включено"
 }

--- a/admin/i18n/uk/translations.json
+++ b/admin/i18n/uk/translations.json
@@ -5,5 +5,6 @@
     "lblIp": "IP-адреса",
     "lblPort": "Порт",
     "lblName": "Ім'я",
-    "lblDevices": "Пристрої"
+    "lblDevices": "Пристрої",
+    "lblEnabled": "Увімкнено"
 }

--- a/admin/i18n/zh-cn/translations.json
+++ b/admin/i18n/zh-cn/translations.json
@@ -5,5 +5,6 @@
     "lblIp": "IP地址",
     "lblPort": "港口",
     "lblName": "姓名",
-    "lblDevices": "设备"
+    "lblDevices": "设备",
+    "lblEnabled": "启用"
 }

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -7,6 +7,8 @@
 			"label": "lblPollInterval",
 			"help": "hlpPollInterval",
 			"default": 60,
+			"min": 5,
+			"max": 3600,
 			"newLine": true,
 			"xs": 12,
 			"sm": 12,
@@ -24,25 +26,42 @@
 			"md": 12,
 			"lg": 12,
 			"xl": 12,
-			"items": [{
-				"type": "text",
-				"width": "33%",
-				"attr": "ip",
-				"title": "lblIp"
-			},
-			{
-				"type": "text",
-				"width": "33%",
-				"attr": "port",
-				"default": 80,
-				"title": "lblPort"
-			},
-			{
-				"type": "text",
-				"width": "33%",
-				"attr": "name",
-				"title": "lblName"
-			}]
+			"items": [
+				{
+					"type": "checkbox",
+					"attr": "enabled",
+					"width": "10% ",
+					"title": "lblEnabled",
+					"filter": false,
+					"sort": false,
+					"default": true
+				},
+				{
+					"type": "text",
+					"width": "35%",
+					"attr": "ip",
+					"title": "lblIp",
+					"validator": "data.ip&&data.ip!=''",
+					"validatorNoSaveOnError": true
+				},
+				{
+					"type": "number",
+					"width": "20%",
+					"attr": "port",
+					"default": 80,
+					"title": "lblPort",
+					"min": 1,
+					"max": 65535
+				},
+				{
+					"type": "text",
+					"width": "35%",
+					"attr": "name",
+					"title": "lblName",
+					"validator": "data.ip&&data.ip!=''",
+					"validatorNoSaveOnError": true
+				}
+			]
 		}
 	}
 }

--- a/main.js
+++ b/main.js
@@ -28,7 +28,7 @@ class Bayernluft extends utils.Adapter {
         this.log.debug(`initDevices()`);
 
         for (const device of this.config.devices) {
-            if (!device.enabed) {
+            if (!device.enabled) {
                 this.log.debug(`Skipping device ${device.name} as not enabled`);
                 continue;
             }

--- a/main.js
+++ b/main.js
@@ -81,7 +81,7 @@ class Bayernluft extends utils.Adapter {
         // If no devices are configured, disable the adapter
         if (!Object.keys(this.devices).length) {
             this.log.error('No devices have been set, terminating...');
-            this.terminate(utils.EXIT_CODES.ADAPTER_REQUESTED_TERMINATION);
+            this.terminate(utils.EXIT_CODES.NO_ERROR);
             return;
         }
 

--- a/main.js
+++ b/main.js
@@ -5,9 +5,12 @@
  */
 
 const utils = require('@iobroker/adapter-core');
+// @ts-expect-error typechecking fails for spread operator
 const NodeFetch = (...args) => import('node-fetch').then(({ default: fetch }) => fetch(...args));
 
 class Bayernluft extends utils.Adapter {
+    devices = {};
+
     constructor(options) {
         super({
             ...options,
@@ -19,32 +22,36 @@ class Bayernluft extends utils.Adapter {
     }
 
     /**
-     * Checks the connections of the devices and sets the connection state accordingly.
+     * Initialices the internal device objects.
      */
-    async checkDeviceConnections() {
-        var isAtLeastOneDeviceReachable = false;
-        for (const device of this.config.devices) {
-            try {
-                const response = await NodeFetch(`http://${device.ip}:${device.port}/`);
-                if (response.ok) {
-                    this.log.debug(`Device ${device.name} is reachable.`);
+    async initDevices() {
+        this.log.debug(`initDevices()`);
 
-                    this.setState(`${device.name}.info.reachable`, true, true);
-                    isAtLeastOneDeviceReachable = true;
-                    //connection state set to true if at least one device is reachable
-                } else {
-                    this.log.warn(`Device ${device.name} is not reachable.`);
-                    this.setState(`${device.name}.info.reachable`, false, true);
-                }
-            } catch (error) {
-                this.log.warn(`Error checking connection for device ${device.name}: ${error.message}`);
-                this.setState(`${device.name}.info.reachable`, false, true);
+        for (const device of this.config.devices) {
+            if (!device.enabed) {
+                this.log.debug(`Skipping device ${device.name} as not enabled`);
+                continue;
             }
-        }
-        if (isAtLeastOneDeviceReachable) {
-            this.setState('info.connection', true, true);
-        } else {
-            this.setState('info.connection', false, true);
+            if (device.name === '') {
+                this.log.warn(`Skipping device with empty name field`);
+                continue;
+            }
+            if (device.ip === '') {
+                this.log.error(`No ip specified for device ${device.name} - will be skipped`);
+            }
+            if (device.port < 0 || device.port > 65535) {
+                this.log.error(`Port ${device.port} is invalid for device ${device.name} - will be skipped`);
+            }
+
+            const dev = {};
+            dev.id = (device.name || '').replace(/[^A-Za-z0-9-_]/, '_');
+            dev.enabled = device.enabled;
+            dev.name = device.name;
+            dev.ip = device.ip;
+            dev.port = device.port;
+            dev.online = device.online;
+
+            this.devices[dev.id] = dev;
         }
     }
 
@@ -54,37 +61,48 @@ class Bayernluft extends utils.Adapter {
     async onReady() {
         // Reset the connection indicator during startup
         this.setState('info.connection', false, true);
+
+        // initialize devices object
+        await this.initDevices();
+
         // If no devices are configured, disable the adapter
-        if (this.config.devices == null) {
+        if (!Object.keys(this.devices).length) {
             this.log.error('No devices have been set, disabling adapter!');
             this.disable();
             return;
         }
 
-        // Create initial objects for configured devices
-        await this.createInitialDeviceObjects();
+        // Create objects for enabled devices
+        await this.createDeviceObjects();
 
         // Check device connections and set info.connection if one is reachable
         await this.checkDeviceConnections();
 
-        //Create objects for configured and reachable devices
-        await this.createDeviceObjects();
-
         //initial device query
         await this.queryDevices();
 
-        //setup polling at interval
+        // limit pollIntervall and start polling
+        let pollInterval = this.config.pollInterval;
+        if (pollInterval < 5) {
+            this.log.info('pollintervall set to 5s');
+            pollInterval = 5;
+        }
+        if (pollInterval > 3600) {
+            this.log.info('pollinterval set to 3600s');
+            pollInterval = 3600;
+        }
+
         this.pollInterval = this.setInterval(async () => {
             // Check device connections and set info.connection if one is reachable
             await this.checkDeviceConnections();
             //device query
             await this.queryDevices();
-        }, this.config.pollInterval * 1000);
+        }, pollInterval * 1000);
     }
 
     /**
      * Is called when adapter shuts down - callback has to be called under any circumstances!
-      
+     *
      * @param callback Callback function
      */
     async onUnload(callback) {
@@ -98,39 +116,75 @@ class Bayernluft extends utils.Adapter {
     }
 
     /**
+     * Checks the connections of the devices and sets the connection state accordingly.
+     */
+    async checkDeviceConnections() {
+        this.log.debug(`checkDeviceConnections()`);
+
+        let isAtLeastOneDeviceReachable = false;
+        for (const id in this.devices) {
+            const device = this.devices[id];
+            this.log.debug(`checking device ${id} - ${device.name} - ${device.ip}:${device.port}`);
+            try {
+                const response = await NodeFetch(`http://${device.ip}:${device.port}/`);
+                if (response.ok) {
+                    this.log.debug(`Device ${device.name} is reachable.`);
+
+                    this.setState(`${device.id}.info.reachable`, true, true);
+                    isAtLeastOneDeviceReachable = true;
+                    //connection state set to true if at least one device is reachable
+                } else {
+                    this.log.warn(`Device ${device.name} is not reachable.`);
+                    this.setState(`${device.id}.info.reachable`, false, true);
+                }
+            } catch (error) {
+                this.log.warn(`Error checking connection for device ${device.name}: ${error.message}`);
+                this.setState(`${device.id}.info.reachable`, false, true);
+            }
+        }
+
+        this.setState('info.connection', isAtLeastOneDeviceReachable, true);
+    }
+
+    /**
      * Query all devices and update states
      */
     async queryDevices() {
-        for await (const device of this.config.devices) {
+        this.log.debug(`queryDevices()`);
+
+        for (const id of this.config.devices) {
+            const device = this.devices[id];
+            this.log.debug(`checking device ${id} - ${device.name} - ${device.ip}:${device.port}`);
             this.queryDevice(device);
         }
     }
 
     /**
      * Query a specific device and update states
-      
+     *
      * @param device The device to query (full device object)
      */
     async queryDevice(device) {
-        //skip device if not reachable
-        this.log.debug(`Querying data for device: ${device.name}`);
-        const isDeviceReachableState = await this.getStateAsync(`${device.name}.info.reachable`);
-        if (isDeviceReachableState && !isDeviceReachableState.val) {
+        this.log.debug(`queryDevice(${device.name})`);
+
+        if (!device.reachable) {
             this.log.warn(`Skip polling for device: ${device.name} (not reachable)`);
             return;
         }
-        this.setState(`${device.name}.info.reachable`, true, true);
-        this.log.debug(`Polling data for device: ${device.name}`);
 
-        const deviceInfo = await this.getHttpRequest(
+        let deviceInfo = {};
+        deviceInfo = await this.getHttpRequest(
             `http://${device.ip}:${device.port}/index.html?export=iobroker&decimal=point`,
-            device.name,
+            device,
         );
 
         if (deviceInfo == null) {
+            this.log.debug(`Response for: ${device.name} - null`);
             return;
         }
+
         this.log.debug(`Response for: ${device.name} - ${JSON.stringify(deviceInfo)}`);
+
         if (deviceInfo.date) {
             this.log.debug(`date: ${deviceInfo.date}`);
             this.setState(`${device.name}.info.date`, deviceInfo.date, true);
@@ -260,26 +314,34 @@ class Bayernluft extends utils.Adapter {
 
     /**
      * Is called if a subscribed state changes
-      
+     *
      * @param id State ID that changed
      * @param state State object with the new state
      */
     async onStateChange(id, state) {
-        this.log.debug(`onStateChange: id: ${id} Value ${state.val} ACK ${state.ack}`);
+        this.log.debug(`onStateChange(id: ${id} Value ${state.val} ACK ${state.ack})`);
 
         if (id && state && !state.ack) {
             const id_splits = id.split('.');
             //const realid = `${id_splits[2]}.${id_splits[3]}.${id_splits[4]}`;
-            const device = await this.getDeviceByName(id_splits[2]);
+            //const device = await this.getDeviceByName(id_splits[2]);
+            const devId = id_splits[2];
+            if (!(devId && this.devices[devId])) {
+                return;
+            }
+
+            const device = this.devices[devId];
+
             this.log.debug(
                 `onStateChange: id: ${id} Device ${device.name} IP ${device.ip} Port ${device.port} Value ${state.val}`,
             );
+
             if (id.includes('.setFanSpeedIn')) {
                 const isSystemOnState = await this.getStateAsync(`${device.name}.info.on`);
                 if (isSystemOnState && !isSystemOnState.val) {
                     const res = await this.sendHttpRequest(
                         `http://${device.ip}:${device.port}/?speedIn=${state.val}`,
-                        device.name,
+                        device,
                     );
                     if (!res) {
                         return this.log.error(
@@ -387,34 +449,93 @@ class Bayernluft extends utils.Adapter {
         }
     }
 
-    /**
-     * Get Device Info by Name
-     *
-     * @param name Device name
-     */
-    async getDeviceByName(name) {
-        const devices = this.config.devices;
-        if (devices == null || !devices) {
-            return null;
-        }
-        let device = null;
-        for await (const devicen of devices) {
-            if (devicen.name == name) {
-                device = devicen;
-                break;
-            }
-        }
-        return device;
-    }
+    // /**
+    //  * Get Device Info by Name
+    //  *
+    //  * @param name Device name
+    //  */
+    // async getDeviceByName(name) {
+    //     this.log.debug(`getDeviceByName(${name})`);
+    //     const devices = this.config.devices;
+    //     if (devices == null || !devices) {
+    //         return null;
+    //     }
+    //     let device = null;
+    //     for await (const devicen of devices) {
+    //         if (devicen.name == name) {
+    //             device = devicen;
+    //             break;
+    //         }
+    //     }
+    //     return device;
+    // }
+
+    // /**
+    //  * Create initial device objects, e.g. if device is reachable
+    //  */
+    // async createInitialDeviceObjects() {
+    //     for await (const device of this.config.devices) {
+    //         //Create Device
+    //         this.extendObject(
+    //             device.name,
+    //             {
+    //                 type: 'device',
+    //                 common: {
+    //                     name: `${device.name}`,
+    //                 },
+    //                 native: {},
+    //             },
+    //             { preserve: { common: ['name'] } },
+    //         );
+
+    //         // Create channels
+    //         await this.extendObject(
+    //             `${device.name}.info`,
+    //             {
+    //                 type: 'channel',
+    //                 common: {
+    //                     name: 'Information',
+    //                 },
+    //                 native: {},
+    //             },
+    //             { preserve: { common: ['name'] } },
+    //         );
+
+    //         // Create reachable indicator
+    //         await this.extendObject(
+    //             `${device.name}.info.reachable`,
+    //             {
+    //                 type: 'state',
+    //                 common: {
+    //                     name: {
+    //                         de: 'Gerät ist erreichbar',
+    //                         en: 'Device is reachable',
+    //                     },
+    //                     type: 'boolean',
+    //                     role: 'indicator.reachable',
+    //                     read: true,
+    //                     write: false,
+    //                 },
+    //                 native: {},
+    //             },
+    //             { preserve: { common: ['name'] } },
+    //         );
+    //     }
+    // }
 
     /**
-     * Create initial device objects, e.g. if device is reachable
+     * Create device specific objects
      */
-    async createInitialDeviceObjects() {
-        for await (const device of this.config.devices) {
-            //Create Device
+    async createDeviceObjects() {
+        this.log.debug(`createDeviceObjects()`);
+
+        for (const id in this.devices) {
+            const device = this.devices[id];
+            this.log.debug(`creating objectsfor device ${id} - ${device.name} - ${device.ip}:${device.port}`);
+
+            //Create device objects
             this.extendObject(
-                device.name,
+                device.id,
                 {
                     type: 'device',
                     common: {
@@ -427,7 +548,7 @@ class Bayernluft extends utils.Adapter {
 
             // Create channels
             await this.extendObject(
-                `${device.name}.info`,
+                `${device.id}.info`,
                 {
                     type: 'channel',
                     common: {
@@ -440,7 +561,7 @@ class Bayernluft extends utils.Adapter {
 
             // Create reachable indicator
             await this.extendObject(
-                `${device.name}.info.reachable`,
+                `${device.id}.info.reachable`,
                 {
                     type: 'state',
                     common: {
@@ -457,23 +578,10 @@ class Bayernluft extends utils.Adapter {
                 },
                 { preserve: { common: ['name'] } },
             );
-        }
-    }
 
-    /**
-     * Create device specific objects
-     */
-    async createDeviceObjects() {
-        for await (const device of this.config.devices) {
-            //skip device if not reachable
-            const isDeviceReachableState = await this.getStateAsync(`${device.name}.info.reachable`);
-            if (isDeviceReachableState && !isDeviceReachableState.val) {
-                this.log.debug(`Skip creating device objects for device: ${device.name} (not reachable)`);
-                continue;
-            }
             // Create channels
             await this.extendObject(
-                `${device.name}.commands`,
+                `${device.id}.commands`,
                 {
                     type: 'channel',
                     common: {
@@ -486,7 +594,7 @@ class Bayernluft extends utils.Adapter {
 
             // Create Objects
             await this.extendObject(
-                `${device.name}.info.date`,
+                `${device.id}.info.date`,
                 {
                     type: 'state',
                     common: {
@@ -505,7 +613,7 @@ class Bayernluft extends utils.Adapter {
             );
 
             await this.extendObject(
-                `${device.name}.info.time`,
+                `${device.id}.info.time`,
                 {
                     type: 'state',
                     common: {
@@ -524,7 +632,7 @@ class Bayernluft extends utils.Adapter {
             );
 
             await this.extendObject(
-                `${device.name}.info.deviceName`,
+                `${device.id}.info.deviceName`,
                 {
                     type: 'state',
                     common: {
@@ -543,7 +651,7 @@ class Bayernluft extends utils.Adapter {
             );
 
             await this.extendObject(
-                `${device.name}.info.mac`,
+                `${device.id}.info.mac`,
                 {
                     type: 'state',
                     common: {
@@ -562,7 +670,7 @@ class Bayernluft extends utils.Adapter {
             );
 
             await this.extendObject(
-                `${device.name}.info.ip`,
+                `${device.id}.info.ip`,
                 {
                     type: 'state',
                     common: {
@@ -581,7 +689,7 @@ class Bayernluft extends utils.Adapter {
             );
 
             await this.extendObject(
-                `${device.name}.info.rssi`,
+                `${device.id}.info.rssi`,
                 {
                     type: 'state',
                     common: {
@@ -600,7 +708,7 @@ class Bayernluft extends utils.Adapter {
             );
 
             await this.extendObject(
-                `${device.name}.info.fwMainController`,
+                `${device.id}.info.fwMainController`,
                 {
                     type: 'state',
                     common: {
@@ -619,7 +727,7 @@ class Bayernluft extends utils.Adapter {
             );
 
             await this.extendObject(
-                `${device.name}.info.fwWiFi`,
+                `${device.id}.info.fwWiFi`,
                 {
                     type: 'state',
                     common: {
@@ -638,7 +746,7 @@ class Bayernluft extends utils.Adapter {
             );
 
             await this.extendObject(
-                `${device.name}.info.on`,
+                `${device.id}.info.on`,
                 {
                     type: 'state',
                     common: {
@@ -657,7 +765,7 @@ class Bayernluft extends utils.Adapter {
             );
 
             await this.extendObject(
-                `${device.name}.temperatureIn`,
+                `${device.id}.temperatureIn`,
                 {
                     type: 'state',
                     common: {
@@ -676,7 +784,7 @@ class Bayernluft extends utils.Adapter {
             );
 
             await this.extendObject(
-                `${device.name}.temperatureOut`,
+                `${device.id}.temperatureOut`,
                 {
                     type: 'state',
                     common: {
@@ -695,7 +803,7 @@ class Bayernluft extends utils.Adapter {
             );
 
             await this.extendObject(
-                `${device.name}.temperatureFresh`,
+                `${device.id}.temperatureFresh`,
                 {
                     type: 'state',
                     common: {
@@ -714,7 +822,7 @@ class Bayernluft extends utils.Adapter {
             );
 
             await this.extendObject(
-                `${device.name}.relativeHumidityIn`,
+                `${device.id}.relativeHumidityIn`,
                 {
                     type: 'state',
                     common: {
@@ -733,7 +841,7 @@ class Bayernluft extends utils.Adapter {
             );
 
             await this.extendObject(
-                `${device.name}.relativeHumidityOut`,
+                `${device.id}.relativeHumidityOut`,
                 {
                     type: 'state',
                     common: {
@@ -752,7 +860,7 @@ class Bayernluft extends utils.Adapter {
             );
 
             await this.extendObject(
-                `${device.name}.absoluteHumidityIn`,
+                `${device.id}.absoluteHumidityIn`,
                 {
                     type: 'state',
                     common: {
@@ -771,7 +879,7 @@ class Bayernluft extends utils.Adapter {
             );
 
             await this.extendObject(
-                `${device.name}.absoluteHumidityOut`,
+                `${device.id}.absoluteHumidityOut`,
                 {
                     type: 'state',
                     common: {
@@ -790,7 +898,7 @@ class Bayernluft extends utils.Adapter {
             );
 
             await this.extendObject(
-                `${device.name}.efficiency`,
+                `${device.id}.efficiency`,
                 {
                     type: 'state',
                     common: {
@@ -809,7 +917,7 @@ class Bayernluft extends utils.Adapter {
             );
 
             await this.extendObject(
-                `${device.name}.humidityTransport`,
+                `${device.id}.humidityTransport`,
                 {
                     type: 'state',
                     common: {
@@ -828,7 +936,7 @@ class Bayernluft extends utils.Adapter {
             );
 
             await this.extendObject(
-                `${device.name}.fanSpeedIn`,
+                `${device.id}.fanSpeedIn`,
                 {
                     type: 'state',
                     common: {
@@ -847,7 +955,7 @@ class Bayernluft extends utils.Adapter {
             );
 
             await this.extendObject(
-                `${device.name}.fanSpeedOut`,
+                `${device.id}.fanSpeedOut`,
                 {
                     type: 'state',
                     common: {
@@ -866,7 +974,7 @@ class Bayernluft extends utils.Adapter {
             );
 
             await this.extendObject(
-                `${device.name}.fanSpeedAntiFreeze`,
+                `${device.id}.fanSpeedAntiFreeze`,
                 {
                     type: 'state',
                     common: {
@@ -885,7 +993,7 @@ class Bayernluft extends utils.Adapter {
             );
 
             await this.extendObject(
-                `${device.name}.isAntiFreezeActive`,
+                `${device.id}.isAntiFreezeActive`,
                 {
                     type: 'state',
                     common: {
@@ -904,7 +1012,7 @@ class Bayernluft extends utils.Adapter {
             );
 
             await this.extendObject(
-                `${device.name}.isFixedSpeedActive`,
+                `${device.id}.isFixedSpeedActive`,
                 {
                     type: 'state',
                     common: {
@@ -923,7 +1031,7 @@ class Bayernluft extends utils.Adapter {
             );
 
             await this.extendObject(
-                `${device.name}.isDefrostModeActive`,
+                `${device.id}.isDefrostModeActive`,
                 {
                     type: 'state',
                     common: {
@@ -942,7 +1050,7 @@ class Bayernluft extends utils.Adapter {
             );
 
             await this.extendObject(
-                `${device.name}.isLandlordModeActive`,
+                `${device.id}.isLandlordModeActive`,
                 {
                     type: 'state',
                     common: {
@@ -961,7 +1069,7 @@ class Bayernluft extends utils.Adapter {
             );
 
             await this.extendObject(
-                `${device.name}.isCrossVentilationActive`,
+                `${device.id}.isCrossVentilationActive`,
                 {
                     type: 'state',
                     common: {
@@ -980,7 +1088,7 @@ class Bayernluft extends utils.Adapter {
             );
 
             await this.extendObject(
-                `${device.name}.isTimerActive`,
+                `${device.id}.isTimerActive`,
                 {
                     type: 'state',
                     common: {
@@ -1000,7 +1108,7 @@ class Bayernluft extends utils.Adapter {
 
             //Create commands
             await this.extendObject(
-                `${device.name}.commands.setFanSpeed`,
+                `${device.id}.commands.setFanSpeed`,
                 {
                     type: 'state',
                     common: {
@@ -1021,7 +1129,7 @@ class Bayernluft extends utils.Adapter {
             );
 
             await this.extendObject(
-                `${device.name}.commands.setFanSpeedIn`,
+                `${device.id}.commands.setFanSpeedIn`,
                 {
                     type: 'state',
                     common: {
@@ -1042,7 +1150,7 @@ class Bayernluft extends utils.Adapter {
             );
 
             await this.extendObject(
-                `${device.name}.commands.setFanSpeedOut`,
+                `${device.id}.commands.setFanSpeedOut`,
                 {
                     type: 'state',
                     common: {
@@ -1063,7 +1171,7 @@ class Bayernluft extends utils.Adapter {
             );
 
             await this.extendObject(
-                `${device.name}.commands.setFanSpeedAntiFreeze`,
+                `${device.id}.commands.setFanSpeedAntiFreeze`,
                 {
                     type: 'state',
                     common: {
@@ -1084,7 +1192,7 @@ class Bayernluft extends utils.Adapter {
             );
 
             await this.extendObject(
-                `${device.name}.commands.powerOn`,
+                `${device.id}.commands.powerOn`,
                 {
                     type: 'state',
                     common: {
@@ -1103,7 +1211,7 @@ class Bayernluft extends utils.Adapter {
             );
 
             await this.extendObject(
-                `${device.name}.commands.powerOff`,
+                `${device.id}.commands.powerOff`,
                 {
                     type: 'state',
                     common: {
@@ -1122,7 +1230,7 @@ class Bayernluft extends utils.Adapter {
             );
 
             await this.extendObject(
-                `${device.name}.commands.togglePower`,
+                `${device.id}.commands.togglePower`,
                 {
                     type: 'state',
                     common: {
@@ -1141,7 +1249,7 @@ class Bayernluft extends utils.Adapter {
             );
 
             await this.extendObject(
-                `${device.name}.commands.autoMode`,
+                `${device.id}.commands.autoMode`,
                 {
                     type: 'state',
                     common: {
@@ -1160,7 +1268,7 @@ class Bayernluft extends utils.Adapter {
             );
 
             await this.extendObject(
-                `${device.name}.commands.timer`,
+                `${device.id}.commands.timer`,
                 {
                     type: 'state',
                     common: {
@@ -1179,7 +1287,7 @@ class Bayernluft extends utils.Adapter {
             );
 
             await this.extendObject(
-                `${device.name}.commands.syncTime`,
+                `${device.id}.commands.syncTime`,
                 {
                     type: 'state',
                     common: {
@@ -1197,40 +1305,42 @@ class Bayernluft extends utils.Adapter {
                 { preserve: { common: ['name'] } },
             );
 
-            this.subscribeStates(`${device.name}.commands.*`);
+            this.subscribeStates(`${device.id}.commands.*`);
         }
     }
 
     /**
      *
      * @param url URL to get Data from
-     * @param deviceName Device Name
+     * @param device device object
      */
-    async getHttpRequest(url, deviceName) {
+    async getHttpRequest(url, device) {
+        this.log.debug(`getHttpRequest(${url},${device.name})`);
+
         let response = null;
         try {
             response = await NodeFetch(url);
         } catch (error) {
-            this.setState(`${deviceName}.info.reachable`, false, true);
+            this.setState(`${device.id}.info.reachable`, false, true);
             if (error.code == 'ETIMEDOUT') {
                 this.log.warn(
-                    `An error has occured while trying to get response from device ${deviceName}. The Connection timed out!`,
+                    `An error has occured while trying to get response from device ${device.name}. Connection timed out!`,
                 );
                 return null;
             }
             if (error.code == 'ECONNREFUSED') {
                 this.log.warn(
-                    `An error has occured while trying to get response from device ${deviceName}. The Connection has been refused!`,
+                    `An error has occured while trying to get response from device ${device.name}. Connection has been refused!`,
                 );
                 return null;
             }
-            this.log.warn(`An unexpected error has occred while trying to get response from device ${deviceName}.`);
+            this.log.warn(`An unexpected error has occured while trying to get response from device ${device.name}.`);
             return null;
         }
 
         let data = null;
         try {
-            data = await response.json();
+            data = response.json();
         } catch (error) {
             if (error.type == 'invalid-json') {
                 this.log.error(
@@ -1241,9 +1351,7 @@ class Bayernluft extends utils.Adapter {
             this.log.error(`Unexpected Error while trying to format json data! ${error}`);
             return null;
         }
-        if (data == null) {
-            return null;
-        }
+
         return data;
     }
 
@@ -1254,6 +1362,8 @@ class Bayernluft extends utils.Adapter {
      * @param deviceName Device Name
      */
     async sendHttpRequest(url, deviceName) {
+        this.log.debug(`sendHttpRequest(${url}, ${deviceName})`);
+
         let response = null;
         try {
             response = await NodeFetch(url);

--- a/main.js
+++ b/main.js
@@ -80,8 +80,8 @@ class Bayernluft extends utils.Adapter {
 
         // If no devices are configured, disable the adapter
         if (!Object.keys(this.devices).length) {
-            this.log.error('No devices have been set, terminating...');
-            this.terminate(utils.EXIT_CODES.NO_ERROR);
+            this.log.error('No devices have been set, disabling adapter!');
+            this.disable();
             return;
         }
 

--- a/main.js
+++ b/main.js
@@ -68,8 +68,8 @@ class Bayernluft extends utils.Adapter {
         // If no devices are configured, disable the adapter
         if (!Object.keys(this.devices).length) {
             this.log.error('No devices have been set, disabling adapter!');
-            this.disable();
-            return;
+            this.terminate(utils.EXIT_CODES.ADAPTER_REQUESTED_TERMINATION);
+            // no reach area
         }
 
         // Create objects for enabled devices


### PR DESCRIPTION
- Link to bayernluft has been added to README.md
- config has been extended with an enable/disable flag to temporary suspend vents
- object id derived from vent name has been modified so that illegal characters are filtered. Object names are restricted to A-Z,a-z,0-9,- and _ now. Original name is stored at name attribute
- interval is now limited to 5 to 3600 seconds
- logging has been modified
- objects are created now independet of reachability
- reachability status of vents is no cached locally


Some required changes are still open - see review checklist.